### PR TITLE
fix: better mobile experience

### DIFF
--- a/apps/site/src/app/nav-bar.tsx
+++ b/apps/site/src/app/nav-bar.tsx
@@ -3,7 +3,8 @@ import Button from '@mui/material/Button';
 import Drawer from '@mui/material/Drawer';
 import ProfileIcon from '@mui/icons-material/AccountCircle';
 import MenuIcon from '@mui/icons-material/Menu';
-import { Grid, StyledButton, ThemeSwitcher } from '@unteris/ui/components';
+import Grid from '@mui/material/Unstable_Grid2';
+import { StyledButton, ThemeSwitcher } from '@unteris/ui/components';
 import { useState } from 'react';
 
 export const NavBar = (props: {
@@ -13,24 +14,24 @@ export const NavBar = (props: {
 
   return (
     <>
-      <Grid columns={12}>
-        <Box>
+      <Grid container={true} columns={{ xs: 4, md: 12 }}>
+        <Grid md={1}>
           <Button onClick={() => setShowMenu(!showMenu)}>
             <MenuIcon />
           </Button>
-        </Box>
-        <Box>
+        </Grid>
+        <Grid md={1}>
           <StyledButton href="/" variant="h2" fontSize="2em">
             Unteris
           </StyledButton>
-        </Box>
-        <Box sx={{ gridColumn: 'span 8' }}></Box>
+        </Grid>
+        <Grid xs={0} md={8}></Grid>
         <ThemeSwitcher setTheme={props.setTheme} />
-        <Box>
+        <Grid md={1}>
           <Button>
             <ProfileIcon />
           </Button>
-        </Box>
+        </Grid>
       </Grid>
       <Drawer
         open={showMenu}

--- a/apps/site/src/app/welcome/welcome.tsx
+++ b/apps/site/src/app/welcome/welcome.tsx
@@ -1,6 +1,6 @@
 import { Theme, Typography, useTheme } from '@mui/material';
 import Box from '@mui/material/Box';
-import { Grid } from '@unteris/ui/components';
+import Grid from '@mui/material/Unstable_Grid2';
 import { ReactNode } from 'react';
 
 const Descriptor = ({
@@ -11,15 +11,16 @@ const Descriptor = ({
   children: ReactNode;
 }): JSX.Element => {
   return (
-    <Box
-      padding={`${theme.spacing()} ${theme.spacing(2)}`}
-      border={`2px solid ${theme.palette.primary[theme.palette.mode]}`}
-      borderRadius={theme.shape.borderRadius}
-      margin={`0 ${theme.spacing(4)}`}
-      minWidth={theme.spacing(50)}
-    >
-      {children}
-    </Box>
+    <Grid xs={12} md={4}>
+      <Box
+        padding={`${theme.spacing()} ${theme.spacing(2)}`}
+        border={`2px solid ${theme.palette.primary[theme.palette.mode]}`}
+        borderRadius={theme.shape.borderRadius}
+        sx={{ minHeight: '4em' }}
+      >
+        {children}
+      </Box>
+    </Grid>
   );
 };
 
@@ -30,6 +31,7 @@ export const Welcome = (): JSX.Element => {
     <Box padding={`${theme.spacing(5)} 0`}>
       <Grid sx={{ justifyItems: 'center', height: '40%' }}>
         <Grid
+          container={true}
           sx={{
             justifyItems: 'center',
             width: '100%',
@@ -41,34 +43,25 @@ export const Welcome = (): JSX.Element => {
             }${opacityMod}), url(./images/vitoak.png)`,
             backgroundRepeat: 'no-repeat, no-repeat',
             backgroundPosition: 'left, right top 40%',
-            columnGap: theme.spacing(),
             padding: `${theme.spacing(8)} ${theme.spacing(2)}`,
             margin: `0 0 ${theme.spacing(2)}`,
           }}
-          columns={6}
+          spacing={theme.spacing()}
         >
-          <Typography
-            variant="h2"
-            sx={{
-              gridColumn: '1 / 3',
-            }}
-            component="h1"
-          >
-            Welcome to Unteris
-          </Typography>
-          <Box
-            sx={{
-              gridColumn: '3/-1',
-            }}
-          ></Box>
+          <Grid xs={12} md={3}>
+            <Typography variant="h2" component="h1">
+              Welcome to Unteris
+            </Typography>
+          </Grid>
         </Grid>
       </Grid>
       <Grid
+        spacing={theme.spacing()}
         sx={{
-          columnGap: theme.spacing(),
           justifyItems: 'center',
           justifyContent: 'center',
         }}
+        container={true}
       >
         <Descriptor theme={theme}>
           Enter a land once torn apart by war and bloodshed, sewn back together

--- a/apps/site/src/app/welcome/welcome.tsx
+++ b/apps/site/src/app/welcome/welcome.tsx
@@ -56,7 +56,7 @@ export const Welcome = (): JSX.Element => {
         </Grid>
       </Grid>
       <Grid
-        spacing={theme.spacing()}
+        spacing={theme.spacing(2)}
         sx={{
           justifyItems: 'center',
           justifyContent: 'center',

--- a/libs/ui/components/src/index.ts
+++ b/libs/ui/components/src/index.ts
@@ -6,3 +6,4 @@ export * from './lib/tab';
 export * from './lib/tab-panel';
 export * from './lib/a11y.props';
 export * from './lib/use-fetch';
+export * from './lib/tabs-with-panel';

--- a/libs/ui/components/src/lib/tab-panel.tsx
+++ b/libs/ui/components/src/lib/tab-panel.tsx
@@ -1,4 +1,5 @@
 import Box from '@mui/material/Box';
+import Grid from '@mui/material/Unstable_Grid2';
 import { ReactNode } from 'react';
 
 interface TabPanelProps {
@@ -10,16 +11,19 @@ interface TabPanelProps {
 
 export const TabPanel = (props: TabPanelProps) => {
   const { children, value, index, ...other } = props;
-
   return (
-    <Box
-      role="tabpanel"
-      hidden={value !== index}
-      id={`vertical-tabpanel-${index}`}
-      aria-labelledby={`vertical-tab-${index}`}
-      {...other}
-    >
-      {value === index && <Box>{children}</Box>}
-    </Box>
+    <Grid container={true}>
+      <Grid>
+        <Box
+          role="tabpanel"
+          hidden={value !== index}
+          id={`vertical-tabpanel-${index}`}
+          aria-labelledby={`vertical-tab-${index}`}
+          {...other}
+        >
+          {value === index && <Box>{children}</Box>}
+        </Box>
+      </Grid>
+    </Grid>
   );
 };

--- a/libs/ui/components/src/lib/tabs-with-panel.tsx
+++ b/libs/ui/components/src/lib/tabs-with-panel.tsx
@@ -1,0 +1,53 @@
+import { useMediaQuery } from '@mui/material';
+import Grid from '@mui/material/Unstable_Grid2';
+import Tabs from '@mui/material/Tabs';
+import { SyntheticEvent } from 'react';
+import { a11yProps } from './a11y.props';
+import { Tab } from './tab';
+import { TabPanel } from './tab-panel';
+
+interface TabsWithPanelProps {
+  ariaLabel: string;
+  tabIndex: number;
+  handleTabChange: (_event: SyntheticEvent, newIndex: number) => void;
+  tabElements: Array<{ id: string; name: string }>;
+  tabPanelContent: (prop: any) => JSX.Element;
+  indicator?: 'primary' | 'secondary';
+}
+
+export const TabsWithPanel = (props: TabsWithPanelProps): JSX.Element => {
+  const isWideEnough = useMediaQuery('(min-width:600px)');
+  return (
+    <Grid
+      container={true}
+      wrap={isWideEnough ? 'nowrap' : 'wrap'}
+      flexShrink={0}
+      columns={isWideEnough ? 12 : 1}
+    >
+      <Tabs
+        orientation={isWideEnough ? 'vertical' : 'horizontal'}
+        value={props.tabIndex}
+        onChange={props.handleTabChange}
+        aria-label={props.ariaLabel}
+        indicatorColor={props.indicator ?? 'primary'}
+        textColor={props.indicator ?? 'primary'}
+        variant={isWideEnough ? 'standard' : 'scrollable'}
+        sx={{
+          borderRight: 1,
+          borderColor: 'divider',
+          alignItems: isWideEnough ? 'start' : 'center',
+          overflow: isWideEnough ? 'unset' : 'hidden',
+        }}
+      >
+        {props.tabElements.map((tab, index) => (
+          <Tab {...a11yProps(index)} label={tab.name} key={tab.id} />
+        ))}
+      </Tabs>
+      {props.tabElements.map((tab, index) => (
+        <TabPanel value={props.tabIndex} index={index} key={index}>
+          {props.tabPanelContent(tab)}
+        </TabPanel>
+      ))}
+    </Grid>
+  );
+};

--- a/libs/ui/components/src/lib/theme-switcher.tsx
+++ b/libs/ui/components/src/lib/theme-switcher.tsx
@@ -1,4 +1,4 @@
-import Box from '@mui/material/Box';
+import Grid from '@mui/material/Unstable_Grid2';
 import Button from '@mui/material/Button';
 import Tooltip from '@mui/material/Tooltip';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
@@ -16,7 +16,7 @@ export const ThemeSwitcher = ({
 
   const isDarkMode = theme.palette.mode === 'dark';
   return (
-    <Box>
+    <Grid xs={1} md={1}>
       <Tooltip
         title={`Turn ${isDarkMode ? 'on' : 'off'} the lights`}
         enterDelay={1000}
@@ -25,6 +25,6 @@ export const ThemeSwitcher = ({
           {isDarkMode ? <LightModeIcon /> : <DarkModeIcon />}
         </Button>
       </Tooltip>
-    </Box>
+    </Grid>
   );
 };

--- a/libs/ui/deities/src/lib/deities-nav.tsx
+++ b/libs/ui/deities/src/lib/deities-nav.tsx
@@ -1,16 +1,9 @@
-import Tabs from '@mui/material/Tabs';
-import {
-  Grid,
-  Tab,
-  TabPanel,
-  a11yProps,
-  useFetchEffect,
-} from '@unteris/ui/components';
+import { useFetchEffect, TabsWithPanel } from '@unteris/ui/components';
 import { SyntheticEvent, useState } from 'react';
 import { DeityPicker } from './diety-picker';
 
 export const DeityNav = (): JSX.Element => {
-  const [tabIndex, setTabIndex] = useState(-1);
+  const [tabIndex, setTabIndex] = useState(0);
   const [locations, setLocations] = useState<
     Array<{ name: string; id: string }>
   >([]);
@@ -26,34 +19,14 @@ export const DeityNav = (): JSX.Element => {
   };
 
   return (
-    <Grid columns={12}>
-      <Tabs
-        orientation="vertical"
-        value={tabIndex}
-        onChange={handleTabChange}
-        aria-label="vertical deity location tab picker"
-        sx={{
-          borderRight: 1,
-          borderColor: 'divider',
-          alignItems: 'start',
-          gridColumn: 'span 2',
-          overflow: 'unset',
-        }}
-      >
-        {locations.map((location, index) => (
-          <Tab {...a11yProps(index)} label={location.name} key={location.id} />
-        ))}
-      </Tabs>
-      {locations.map((location, index) => (
-        <TabPanel
-          value={tabIndex}
-          index={index}
-          key={index}
-          gridColumn="span 10"
-        >
-          <DeityPicker location={location} />
-        </TabPanel>
-      ))}
-    </Grid>
+    <TabsWithPanel
+      ariaLabel="deity location tab picker"
+      tabIndex={tabIndex}
+      handleTabChange={handleTabChange}
+      tabElements={locations}
+      tabPanelContent={(location) => {
+        return <DeityPicker location={location} />;
+      }}
+    />
   );
 };

--- a/libs/ui/deities/src/lib/deity-viewer.tsx
+++ b/libs/ui/deities/src/lib/deity-viewer.tsx
@@ -1,8 +1,8 @@
 import Box from '@mui/material/Box';
+import Grid from '@mui/material/Unstable_Grid2';
 // import Button from '@mui/material/Button';
 // import EditIcon from '@mui/icons-material/Edit';
 import Typography from '@mui/material/Typography';
-import { Grid } from '@unteris/ui/components';
 import { Deity } from './deity.interface';
 
 interface DeityViewerProps {
@@ -15,16 +15,9 @@ export const DeityViewer = ({
 }: // setIsEditing,
 DeityViewerProps): JSX.Element => {
   return (
-    <Grid columns={12}>
-      <Box
-        sx={{
-          gridColumn: 'span 4',
-          paddingLeft: '1em',
-          display: 'grid',
-          gridColumnTemplate: 'fr',
-        }}
-      >
-        <Box>
+    <Grid container={true}>
+      <Grid container={true} direction="column" xs={12} md={6}>
+        <Grid alignSelf="center">
           <Typography variant="h2" fontSize="3.25rem">
             {deity.name}
 
@@ -32,24 +25,36 @@ DeityViewerProps): JSX.Element => {
               <EditIcon />
             </Button>*/}
           </Typography>
-        </Box>
-        <Typography variant="body1">{deity.description}</Typography>
-        {deity.domains?.length ? (
-          <Typography variant="body1">
-            Domains: {deity.domains?.join(', ')}
-          </Typography>
-        ) : (
-          <Box />
-        )}
+        </Grid>
+        <Grid>
+          <Typography variant="body1">{deity.description}</Typography>
+        </Grid>
+        <Grid>
+          {deity.domains?.length ? (
+            <Typography variant="body1">
+              Domains: {deity.domains?.join(', ')}
+            </Typography>
+          ) : (
+            <Box />
+          )}
+        </Grid>
         <Box />
-      </Box>
-      <Box sx={{ gridColumn: 'span 8', maxHeight: '75vh', maxWidth: '100%' }}>
-        <img
-          src={deity.imageUrl}
-          alt={`${deity.name}`}
-          style={{ width: '100%', height: '100%', objectFit: 'contain' }}
-        />
-      </Box>
+      </Grid>
+      <Grid md={6} xs={12}>
+        <Box>
+          <img
+            src={deity.imageUrl}
+            alt={`${deity.name}`}
+            style={{
+              width: '100%',
+              height: '100%',
+              maxHeight: '600px',
+              objectFit: 'contain',
+              padding: '0 1em',
+            }}
+          />
+        </Box>
+      </Grid>
     </Grid>
   );
 };

--- a/libs/ui/deities/src/lib/deity.tsx
+++ b/libs/ui/deities/src/lib/deity.tsx
@@ -1,14 +1,17 @@
+import Box from '@mui/material/Box';
 import { useState } from 'react';
 import { useFetchEffect } from '@unteris/ui/components';
 import type { Deity as IDeity } from './deity.interface';
 import { DeityEditor } from './deity-editor';
 import { DeityViewer } from './deity-viewer';
+import { useMediaQuery } from '@mui/material';
 
 interface DeityProps {
   deity: { id: string; name: string };
 }
 
 export const Deity = (props: DeityProps): JSX.Element => {
+  const isWideEnough = useMediaQuery('(min-width:600px)');
   const [deity, setDeity] = useState<IDeity>();
   const [isEditing, setIsEditing] = useState(false);
 
@@ -26,13 +29,17 @@ export const Deity = (props: DeityProps): JSX.Element => {
     return <div />;
   }
 
-  return isEditing ? (
-    <DeityEditor
-      deity={deity}
-      setDeity={updateDeity}
-      setIsEditing={setIsEditing}
-    />
-  ) : (
-    <DeityViewer deity={deity} setIsEditing={setIsEditing} />
+  return (
+    <Box padding={`${!isWideEnough ? '1em' : '0'} 1em`}>
+      {isEditing ? (
+        <DeityEditor
+          deity={deity}
+          setDeity={updateDeity}
+          setIsEditing={setIsEditing}
+        />
+      ) : (
+        <DeityViewer deity={deity} setIsEditing={setIsEditing} />
+      )}
+    </Box>
   );
 };

--- a/libs/ui/deities/src/lib/diety-picker.tsx
+++ b/libs/ui/deities/src/lib/diety-picker.tsx
@@ -1,11 +1,4 @@
-import Tabs from '@mui/material/Tabs';
-import {
-  Grid,
-  a11yProps,
-  Tab,
-  TabPanel,
-  useFetchEffect,
-} from '@unteris/ui/components';
+import { TabsWithPanel, useFetchEffect } from '@unteris/ui/components';
 import { SyntheticEvent, useState } from 'react';
 import { Deity } from './deity';
 
@@ -30,34 +23,15 @@ export const DeityPicker = (props: DeityPickerProps): JSX.Element => {
   });
 
   return (
-    <Grid columns={12}>
-      <Tabs
-        orientation="vertical"
-        value={tabIndex}
-        onChange={handleTabChange}
-        aria-label="vertical deity tab picker"
-        sx={{
-          borderRight: 1,
-          borderColor: 'divider',
-          alignItems: 'start',
-          overflow: 'unset',
-          gridColumn: 'span 2',
-        }}
-      >
-        {deities.map((deity, index) => (
-          <Tab label={deity.name} key={index} {...a11yProps(index)}></Tab>
-        ))}
-      </Tabs>
-      {deities.map((deity, index) => (
-        <TabPanel
-          value={tabIndex}
-          index={index}
-          key={index}
-          gridColumn="span 10"
-        >
-          <Deity deity={deity} />
-        </TabPanel>
-      ))}
-    </Grid>
+    <TabsWithPanel
+      ariaLabel="deity tab picker"
+      tabIndex={tabIndex}
+      handleTabChange={handleTabChange}
+      tabElements={deities}
+      tabPanelContent={(deity) => {
+        return <Deity deity={deity} />;
+      }}
+      indicator="secondary"
+    />
   );
 };

--- a/libs/ui/history/src/lib/history.tsx
+++ b/libs/ui/history/src/lib/history.tsx
@@ -57,7 +57,13 @@ export const History = (): JSX.Element => {
         new land.
       </HistoryBlurb>
       <Grid sx={{ justifyItems: 'center' }}>
-        <img src="images/unteris_map.jpg" alt="Unteris Map" width="80%" />
+        <a
+          href="images/unteris_map.jpg"
+          target="_blank"
+          style={{ padding: '0 10%' }}
+        >
+          <img src="images/unteris_map.jpg" alt="Unteris Map" width="100%" />
+        </a>
       </Grid>
     </>
   );


### PR DESCRIPTION
I've swapped out the use of a CSS grid for the Material UI Grid component which is a CSS Flexbox. The mobile experience now looks much better and acts as you would generally expect it to. There's still a weird jitter when swapping between deities on desktop, but it's minimal for now. I'll get it fixed eventually.