### PR TITLE
fix: create schema and dtos for controllers missing them

### DIFF
--- a/libs/server/deities/src/lib/models/category-param.dto.ts
+++ b/libs/server/deities/src/lib/models/category-param.dto.ts
@@ -1,0 +1,6 @@
+import { ZodDtoClass } from '@unteris/server/zod-pipe';
+import { CategoryParamSchema } from '@unteris/shared/types';
+
+export class CategoryParamDto extends ZodDtoClass<typeof CategoryParamSchema> {
+  static override schema = CategoryParamSchema;
+}

--- a/libs/server/deities/src/lib/models/id-param.dto.ts
+++ b/libs/server/deities/src/lib/models/id-param.dto.ts
@@ -1,0 +1,6 @@
+import { ZodDtoClass } from '@unteris/server/zod-pipe';
+import { IdParamSchema } from '@unteris/shared/types';
+
+export class IdParamDto extends ZodDtoClass<typeof IdParamSchema> {
+  static override schema = IdParamSchema;
+}

--- a/libs/server/deities/src/lib/models/location-param.dto.ts
+++ b/libs/server/deities/src/lib/models/location-param.dto.ts
@@ -1,0 +1,6 @@
+import { ZodDtoClass } from '@unteris/server/zod-pipe';
+import { LocationParamSchema } from '@unteris/shared/types';
+
+export class LocationParamDto extends ZodDtoClass<typeof LocationParamSchema> {
+  static override schema = LocationParamSchema;
+}

--- a/libs/server/deities/src/lib/server-deities.controller.ts
+++ b/libs/server/deities/src/lib/server-deities.controller.ts
@@ -1,4 +1,7 @@
 import { Controller, Get, Param } from '@nestjs/common';
+import { CategoryParamDto } from './models/category-param.dto';
+import { IdParamDto } from './models/id-param.dto';
+import { LocationParamDto } from './models/location-param.dto';
 import { ServerDeitiesService } from './server-deities.service';
 
 @Controller('deities')
@@ -6,17 +9,17 @@ export class ServerDeitiesController {
   constructor(private serverDeitiesService: ServerDeitiesService) {}
 
   @Get('category/:category')
-  async getDeitiesByCategory(@Param() { category }: { category: string }) {
-    return this.serverDeitiesService.findDeitiesOfCategory(category);
+  async getDeitiesByCategory(@Param() param: CategoryParamDto) {
+    return this.serverDeitiesService.findDeitiesOfCategory(param.data.category);
   }
 
   @Get('id/:id')
-  async getDeityById(@Param() { id }: { id: string }) {
-    return this.serverDeitiesService.getDeityById(id);
+  async getDeityById(@Param() param: IdParamDto) {
+    return this.serverDeitiesService.getDeityById(param.data.id);
   }
 
   @Get('location/:location')
-  async getDeitiesByLocation(@Param() { location }: { location: string }) {
-    return this.serverDeitiesService.findDeitiesOfLocation(location);
+  async getDeitiesByLocation(@Param() param: LocationParamDto) {
+    return this.serverDeitiesService.findDeitiesOfLocation(param.data.location);
   }
 }

--- a/libs/server/race/src/lib/models/id-param.dto.ts
+++ b/libs/server/race/src/lib/models/id-param.dto.ts
@@ -1,0 +1,6 @@
+import { ZodDtoClass } from '@unteris/server/zod-pipe';
+import { IdParamSchema } from '@unteris/shared/types';
+
+export class IdParamDto extends ZodDtoClass<typeof IdParamSchema> {
+  static override schema = IdParamSchema;
+}

--- a/libs/server/race/src/lib/race.controller.ts
+++ b/libs/server/race/src/lib/race.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Param } from '@nestjs/common';
+import { IdParamDto } from './models/id-param.dto';
 import { ServerRaceService } from './race.service';
 
 @Controller('race')
@@ -11,7 +12,7 @@ export class ServerRaceController {
   }
 
   @Get(':id')
-  async getRaceWithAbilities(@Param() { id }: { id: string }) {
-    return this.serverRaceService.getRaceWithAbilities(id);
+  async getRaceWithAbilities(@Param() param: IdParamDto) {
+    return this.serverRaceService.getRaceWithAbilities(param.data.id);
   }
 }

--- a/libs/shared/types/src/index.ts
+++ b/libs/shared/types/src/index.ts
@@ -12,3 +12,4 @@ export * from './lib/role';
 export * from './lib/user-account';
 export * from './lib/user-permission';
 export * from './lib/auth';
+export * from './lib/deities';

--- a/libs/shared/types/src/lib/deities/category-param-dto.ts
+++ b/libs/shared/types/src/lib/deities/category-param-dto.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const CategoryParamSchema = z.object({
+  category: z.string().ulid(),
+});
+
+export type CategoryParam = z.infer<typeof CategoryParamSchema>;

--- a/libs/shared/types/src/lib/deities/id-param-dto.ts
+++ b/libs/shared/types/src/lib/deities/id-param-dto.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const IdParamSchema = z.object({
+  id: z.string().ulid(),
+});
+
+export type IdParam = z.infer<typeof IdParamSchema>;

--- a/libs/shared/types/src/lib/deities/index.ts
+++ b/libs/shared/types/src/lib/deities/index.ts
@@ -1,0 +1,3 @@
+export * from './category-param-dto';
+export * from './id-param-dto';
+export * from './location-param-dto';

--- a/libs/shared/types/src/lib/deities/location-param-dto.ts
+++ b/libs/shared/types/src/lib/deities/location-param-dto.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const LocationParamSchema = z.object({
+  location: z.string().ulid(),
+});
+
+export type LocationParam = z.infer<typeof LocationParamSchema>;


### PR DESCRIPTION
Next PR I should have the ZodDtoPipe just skip if the schema is not a valid zod schema (i.e. it's not actually supposed to be validated)