### PR TITLE
fix: strict same site cookies non-json logging and dev docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ docker/*
 !libs/docker/
 *.log
 dump
+.env

--- a/apps/image-server/src/main.ts
+++ b/apps/image-server/src/main.ts
@@ -1,4 +1,3 @@
-import { Logger } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
 import { Transport } from "@nestjs/microservices";
 import { OgmaService } from "@ogma/nestjs-module";
@@ -19,9 +18,10 @@ async function bootstrap() {
 			},
 		},
 	});
-	app.useLogger(app.get(OgmaService));
+	const logger = app.get(OgmaService);
+	app.useLogger(logger);
 	await app.listen();
-	Logger.log("🚀 Image Processing Server up and running!");
+	logger.log("🚀 Image Processing Server up and running!");
 }
 
 bootstrap();

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -1,4 +1,3 @@
-import { Logger } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
 import { OgmaService } from "@ogma/nestjs-module";
 import { ServerConfigService } from "@unteris/server/config";
@@ -8,7 +7,8 @@ async function bootstrap() {
 	const app = await NestFactory.create(RootModule, { bufferLogs: true });
 	const globalPrefix = "api";
 	app.setGlobalPrefix(globalPrefix);
-	app.useLogger(app.get(OgmaService));
+	const logger = app.get(OgmaService);
+	app.useLogger(logger);
 	const config = app.get(ServerConfigService);
 	const port = process.env.PORT || 3333;
 	app.enableCors({
@@ -17,7 +17,7 @@ async function bootstrap() {
 	});
 	app.getHttpAdapter().getInstance().set("trust proxy", true);
 	await app.listen(port, () => {
-		Logger.log(`Listening at http://localhost:${port}/${globalPrefix}`);
+		logger.log(`🚀 Listening at http://localhost:${port}/${globalPrefix}`);
 	});
 }
 

--- a/apps/site/Dockerfile
+++ b/apps/site/Dockerfile
@@ -20,13 +20,14 @@ COPY package.json \
 	./
 ENV CYPRESS_INSTALL_BINARY=0
 RUN pnpm i
-  
+
 FROM unteris-common AS site-build
+ARG SERVER_URL=https://api.unteris.com
 WORKDIR /src
 COPY apps/site ./apps/site
 COPY libs/ui ./libs/ui
 COPY libs/shared ./libs/shared/
-RUN VITE_SERVER_URL="https://api.unteris.com" pnpm nx run site:build:production
+RUN VITE_SERVER_URL=$SERVER_URL pnpm nx run site:build:production
 
 FROM caddy:2.6.4-alpine as site-prod
 LABEL description="The Unteris website image, ran via a Caddy reverse proxy"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,95 @@
+version: '3'
+name: unteris-dev
+
+services:
+  site:
+    build:
+      context: .
+      dockerfile: ./apps/site/Dockerfile
+      args:
+        SERVER_URL: http://localhost:3333/api
+    ports:
+      - '127.0.0.1:8080:80'
+    volumes:
+      - './apps/site/public/images:/src/dist/apps/site/images'
+    labels:
+      - 'com.centurylinklabs.watchtower.enable=true'
+  server:
+    build:
+      context: .
+      dockerfile: ./apps/server/Dockerfile
+    logging:
+      driver: local
+    env_file: .env
+    environment:
+      DATABASE_HOST: postgres
+      RABBIT_HOST: rabbit
+    volumes:
+      - './apps/site/public/images:/src/images'
+    ports:
+      - '127.0.0.1:3333:3333'
+    depends_on:
+      - postgres
+      - redis
+      - rabbit
+    labels:
+      - 'com.centurylinklabs.watchtower.enable=true'
+  image-server:
+    build:
+      context: .
+      dockerfile: ./apps/image-server/Dockerfile
+    logging:
+      driver: local
+    env_file: .env
+    environment:
+      DATABASE_HOST: postgres
+      RABBIT_HOST: rabbit
+    volumes:
+      - './apps/site/public/images:/src/images'
+    depends_on:
+      - postgres
+      - rabbit
+    labels:
+      - 'com.centurylinklabs.watchtower.enable=true'
+  migrations:
+    build:
+      context: .
+      dockerfile: ./apps/kysely-cli/Dockerfile
+    env_file: .env
+    environment:
+      DATABASE_HOST: postgres
+      RABBIT_HOST: rabbit
+    logging:
+      driver: local
+    depends_on:
+      - postgres
+    labels:
+      - 'com.centurylinklabs.watchtower.enable=true'
+  postgres:
+    build:
+      context: .
+      dockerfile: ./apps/postgres/Dockerfile
+    env_file: .env
+    ports:
+      - '127.0.0.1:5433:5432'
+    environment:
+      POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
+      POSTGRES_USER: ${DATABASE_USER}
+      POSTGRES_DB: ${DATABASE_NAME}
+    labels:
+      - 'com.centurylinklabs.watchtower.enable=true'
+    volumes:
+      - ./tmp/postgres-data:/var/lib/postgreslq/data
+  redis:
+    image: redis:7.2.1
+    ports:
+      - '127.0.0.1:6380:6379'
+    # command: redis-server /usr/local/etc/redis/redis.conf
+  rabbit:
+    image: rabbitmq:3.12.6
+    ports:
+      - '127.0.0.1:5673:5672'
+      - '127.0.0.1:15673:15672'
+    environment:
+      RABBITMQ_DEFAULT_USER: rabbit
+      RABBITMQ_DEFAULT_PASS: rabbit

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,5 +1,6 @@
 version: '3'
 name: unteris-e2e
+
 services:
   postgres:
     build:

--- a/libs/server/logging/src/lib/server-logging.module.ts
+++ b/libs/server/logging/src/lib/server-logging.module.ts
@@ -7,12 +7,7 @@ import {
 	ServerConfigService,
 } from "@unteris/server/config";
 
-@Module({
-	imports: [],
-	controllers: [],
-	providers: [],
-	exports: [],
-})
+@Module({})
 export class ServerLoggingModule {
 	static forApplication(
 		app: string,
@@ -26,7 +21,6 @@ export class ServerLoggingModule {
 					useFactory: (config: ServerConfigService) => ({
 						application: app,
 						logLevel: logLevel,
-						json: config.get("NODE_ENV") === "production",
 					}),
 					inject: [ServerConfigService],
 				}),

--- a/libs/server/session/src/lib/session.service.ts
+++ b/libs/server/session/src/lib/session.service.ts
@@ -106,7 +106,7 @@ export class ServerSessionService {
 		value: string | number;
 		options?: Cookie["options"];
 	}): Cookie {
-		const cookie = {
+		const cookie: Required<Cookie> = {
 			name: `${name}Id`,
 			value,
 			options: {
@@ -115,6 +115,7 @@ export class ServerSessionService {
 				),
 				httpOnly: true,
 				path: "/api",
+				sameSite: "Strict" as const,
 				...options,
 			},
 		};


### PR DESCRIPTION
As I look at the docker logs directly, and not through something like grafana or prmetheus, it's better to keep them in the stream string format.

Cookies should now be set to SameSite=Strict to allow them to work properly in a production environment (hopefully).

There's now a docker-compose.dev.yml that immitates the docker-compose.prod.yml to allow for a "full test" of the system